### PR TITLE
Link to GitHub Pages website for User Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ The [documentation template](https://github.com/ONSdigital/sml-supporting-info/b
 ## License
 Unless stated otherwise, the SML codebase is released under the [MIT License](https://github.com/ONSdigital/sml-python-small/blob/main/LICENSE). This covers both the codebase and any sample code in the documentation.
 
-The documentation is available under the terms of the [Open Government 3.0 license](https://github.com/ONSdigital/sml-supporting-info/blob/main/LICENSE).
+The documentation is available under the terms of the [Open Government 3.0 license](https://github.com/ONSdigital/sml-supporting-info/blob/main/LICENSE). 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 > [!CAUTION]  
 > We are using a new repository to store SML user documentation. 
-> Our current User Guides and example data can be found in the [SML User Docs](https://github.com/ONSdigital/sml-user-docs) repository.
-
+> Our current User Guides and example data can be found [here:](https://onsdigital.github.io/sml-public/intro.html).
 
 # Overview
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > [!CAUTION]  
 > We are using a new repository to store SML user documentation. 
-> Our current User Guides and example data can be found [here:](https://onsdigital.github.io/sml-public/intro.html).
+> Our current User Guides and example data can be found [here](https://onsdigital.github.io/sml-public/intro.html).
 
 # Overview
 

--- a/method-info/date-adjustment/date_adjustment.md
+++ b/method-info/date-adjustment/date_adjustment.md
@@ -177,4 +177,4 @@ The ONS Statistical Methods Library at [https://statisticalmethodslibrary.ons.go
 ## License
 Unless stated otherwise, the SML codebase is released under the [MIT License](https://github.com/ONSdigital/sml-python-small/blob/main/LICENSE). This covers both the codebase and any sample code in the documentation.
 
-The documentation is available under the terms of the [Open Government 3.0 license](https://github.com/ONSdigital/sml-supporting-info/blob/main/LICENSE).
+The documentation is available under the terms of the [Open Government 3.0 license](https://github.com/ONSdigital/sml-supporting-info/blob/main/LICENSE). 

--- a/method-info/date-adjustment/date_adjustment.md
+++ b/method-info/date-adjustment/date_adjustment.md
@@ -2,7 +2,7 @@
 
 > [!CAUTION]  
 > This is an old version of our User Notes.
-> Our current User Guides and example data can be found in the [SML User Docs](https://github.com/ONSdigital/sml-user-docs) repository.
+> Our current User Guides and example data can be found here: [Date Adjustment](https://onsdigital.github.io/sml-public/public_guides/DateAdjustment.html).
 
 ## Finding and Installing the Method
 You can find instructions on downloading and installing the method in the [Help centre](https://statisticalmethodslibrary.ons.gov.uk/help-centre/index) of the [ONS Statistical Methods Library](https://statisticalmethodslibrary.ons.gov.uk)

--- a/method-info/selective-editing/selective_editing.md
+++ b/method-info/selective-editing/selective_editing.md
@@ -133,4 +133,4 @@ The ONS Statistical Methods Library at [https://statisticalmethodslibrary.ons.go
 ## License
 Unless stated otherwise, the SML codebase is released under the [MIT License](https://github.com/ONSdigital/sml-python-small/blob/main/LICENSE). This covers both the codebase and any sample code in the documentation.
 
-The documentation is available under the terms of the [Open Government 3.0 license](https://github.com/ONSdigital/sml-supporting-info/blob/main/LICENSE).
+The documentation is available under the terms of the [Open Government 3.0 license](https://github.com/ONSdigital/sml-supporting-info/blob/main/LICENSE). 

--- a/method-info/selective-editing/selective_editing.md
+++ b/method-info/selective-editing/selective_editing.md
@@ -2,7 +2,7 @@
 
 > [!CAUTION]  
 > This is an old version of our User Notes.
-> Our current User Guides and example data can be found in the [SML User Docs](https://github.com/ONSdigital/sml-user-docs) repository.
+> Our current User Guides and example data can be found here: [Selective Editing](https://onsdigital.github.io/sml-public/public_guides/SelectiveEditing.html).
 
 ## Finding and Installing the Method
 You can find instructions on downloading and installing the method in the [Help centre](https://statisticalmethodslibrary.ons.gov.uk/help-centre/index) of the [ONS Statistical Methods Library](https://statisticalmethodslibrary.ons.gov.uk)

--- a/method-info/thousand-pound-correction/thousand_pound_correction.md
+++ b/method-info/thousand-pound-correction/thousand_pound_correction.md
@@ -154,4 +154,4 @@ The ONS Statistical Methods Library at [https://statisticalmethodslibrary.ons.go
 ## License
 Unless stated otherwise, the SML codebase is released under the [MIT License](https://github.com/ONSdigital/sml-python-small/blob/main/LICENSE). This covers both the codebase and any sample code in the documentation.
 
-The documentation is available under the terms of the [Open Government 3.0 license](https://github.com/ONSdigital/sml-supporting-info/blob/main/LICENSE).
+The documentation is available under the terms of the [Open Government 3.0 license](https://github.com/ONSdigital/sml-supporting-info/blob/main/LICENSE). 

--- a/method-info/thousand-pound-correction/thousand_pound_correction.md
+++ b/method-info/thousand-pound-correction/thousand_pound_correction.md
@@ -2,7 +2,7 @@
 
 > [!CAUTION]  
 > This is an old version of our User Notes.
-> Our current User Guides and example data can be found in the [SML User Docs](https://github.com/ONSdigital/sml-user-docs) repository.
+> Our current User Guides and example data can be found here: [Thousand Pound Correction](https://onsdigital.github.io/sml-public/public_guides/ThousandPoundCorrection.html).
 
 ## Finding and Installing the Method
 

--- a/method-info/totals-and-components/totals-and-components.md
+++ b/method-info/totals-and-components/totals-and-components.md
@@ -144,4 +144,4 @@ and a link to the github repository which contains detailed API information as p
 
 Unless stated otherwise, the SML codebase is released under the [MIT License](https://github.com/ONSdigital/sml-python-small/blob/main/LICENSE). This covers both the codebase and any sample code in the documentation.
 
-The documentation is available under the terms of the [Open Government 3.0 license](https://github.com/ONSdigital/sml-supporting-info/blob/main/LICENSE).
+The documentation is available under the terms of the [Open Government 3.0 license](https://github.com/ONSdigital/sml-supporting-info/blob/main/LICENSE). 

--- a/method-info/totals-and-components/totals-and-components.md
+++ b/method-info/totals-and-components/totals-and-components.md
@@ -2,7 +2,7 @@
 
 > [!CAUTION]  
 > This is an old version of our User Notes.
-> Our current User Guides and example data can be found in the [SML User Docs](https://github.com/ONSdigital/sml-user-docs) repository.
+> Our current User Guides and example data can be found here: [Totals And Components](https://onsdigital.github.io/sml-public/public_guides/TotalsAndComponents.html).
 
 ## Finding and Installing the Method
 


### PR DESCRIPTION
Update links to User Guides to point to the GitHub Pages website as we are no longer using the sml-user-docs repo.